### PR TITLE
`chrome` and `platform`: Reverse order by default

### DIFF
--- a/src/pages/board/[board].tsx
+++ b/src/pages/board/[board].tsx
@@ -33,12 +33,12 @@ const sortImages = (
       case "chrome": {
         const av = parseChromeVersion(a.chrome);
         const bv = parseChromeVersion(b.chrome);
-        return sortVersions(av, bv);
+        return sortVersions(av, bv).reverse();
       }
       case "platform": {
         const av = parsePlatformVersion(a.platform);
         const bv = parsePlatformVersion(b.platform);
-        return sortVersions(av, bv);
+        return sortVersions(av, bv).reverse();
       }
       case "lastModified":
         return (

--- a/src/pages/board/[board].tsx
+++ b/src/pages/board/[board].tsx
@@ -33,12 +33,12 @@ const sortImages = (
       case "chrome": {
         const av = parseChromeVersion(a.chrome);
         const bv = parseChromeVersion(b.chrome);
-        return sortVersions(av, bv).reverse();
+        return sortVersions(av, bv);
       }
       case "platform": {
         const av = parsePlatformVersion(a.platform);
         const bv = parsePlatformVersion(b.platform);
-        return sortVersions(av, bv).reverse();
+        return sortVersions(av, bv);
       }
       case "lastModified":
         return (

--- a/src/pages/board/[board].tsx
+++ b/src/pages/board/[board].tsx
@@ -159,6 +159,7 @@ const BoardPage: NextPage<Props> = (props) => {
       <label>
         <input
           type="checkbox"
+          defaultChecked={sortReverse}
           onChange={(e) => setSortReverse(e.currentTarget.checked)}
         />{" "}
         Reverse

--- a/src/pages/board/[board].tsx
+++ b/src/pages/board/[board].tsx
@@ -109,7 +109,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({
 };
 
 const BoardPage: NextPage<Props> = (props) => {
-  const [sortReverse, setSortReverse] = useState(false);
+  const [sortReverse, setSortReverse] = useState(true);
   const [sortOrder, setSortOrder] = useState<SortOrder>("lastModified");
 
   if (isErrorProps(props))


### PR DESCRIPTION
Users are more than likely going to want to see recent versions before old versions. This simply defaults to reversing the order for platform/chrome version (latest version is already latest first).