### PR TITLE
qol: update notdarkn & diffusehyperion mirrors

### DIFF
--- a/src/shim.ts
+++ b/src/shim.ts
@@ -10,99 +10,135 @@ export type ShimMirror = {
 
 export const shimMirrors: ShimMirror[] = [
   {
-    name: "DiffuseHyperion Mirror",
+    name: "NotDarkn Mirror",
     shims: [
-      { url: "https://dl.diffusehyperion.com/rma/brask.zip", codename: "brask" },
-      { url: "https://dl.diffusehyperion.com/rma/brya.zip", codename: "brya" },
-      {
-        url: "https://dl.diffusehyperion.com/rma/clapper.zip",
-        codename: "clapper",
+      { 
+        url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/ambassador.zip", 
+        codename: "ambassador" 
       },
-      { url: "https://dl.diffusehyperion.com/rma/coral.zip", codename: "coral" },
-      {
-        url: "https://dl.diffusehyperion.com/rma/corsola.zip",
-        codename: "corsola",
+      { url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/brask.zip", codename: "brask" },
+      { url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/brya.zip", codename: "brya" },
+      { url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/clapper.zip", 
+      codename: "clapper" 
+
       },
-      {
-        url: "https://dl.diffusehyperion.com/rma/dedede.zip",
-        codename: "dedede",
+      { url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/coral.zip", codename: "coral" },
+      { 
+        url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/corsola.zip", 
+        codename: "corsola" 
       },
-      {
-        url: "https://dl.diffusehyperion.com/rma/enguarde.zip",
-        codename: "enguarde",
+      { 
+        url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/dedede.zip", 
+        codename: "dedede" 
       },
-      {
-        url: "https://dl.diffusehyperion.com/rma/glimmer.zip",
-        codename: "glimmer",
+      { 
+        url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/enguarde.zip", 
+        codename: "enguarde" 
       },
-      { url: "https://dl.diffusehyperion.com/rma/grunt.zip", codename: "grunt" },
-      { url: "https://dl.diffusehyperion.com/rma/hana.zip", codename: "hana" },
-      { url: "https://dl.diffusehyperion.com/rma/hatch.zip", codename: "hatch" },
-      {
-        url: "https://dl.diffusehyperion.com/rma/jacuzzi.zip",
-        codename: "jacuzzi",
+      { 
+        url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/glimmer.zip", 
+        codename: "glimmer" 
       },
-      { url: "https://dl.diffusehyperion.com/rma/kukui.zip", codename: "kukui" },
-      { url: "https://dl.diffusehyperion.com/rma/nami.zip", codename: "nami" },
-      {
-        url: "https://dl.diffusehyperion.com/rma/octopus.zip",
-        codename: "octopus",
+      { url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/grunt.zip", codename: "grunt" },
+      { url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/hana.zip", codename: "hana" },
+      { url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/hatch.zip", codename: "hatch" },
+      { 
+        url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/jacuzzi.zip", 
+        codename: "jacuzzi" 
       },
-      { url: "https://dl.diffusehyperion.com/rma/orco.zip", codename: "orco" },
-      { url: "https://dl.diffusehyperion.com/rma/pyro.zip", codename: "pyro" },
-      { url: "https://dl.diffusehyperion.com/rma/reks.zip", codename: "reks" },
-      {
-        url: "https://dl.diffusehyperion.com/rma/sentry.zip",
-        codename: "sentry",
+      { url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/kefka.zip", codename: "kefka" },
+      { url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/kukui.zip",  codename: "kukui" },
+      { url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/lulu.zip", codename: "lulu" },
+      { url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/nami.zip", codename: "nami" },
+      { url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/nissa.zip", codename: "nissa" },
+      { 
+        url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/octopus.zip", 
+        codename: "octopus" 
       },
-      { url: "https://dl.diffusehyperion.com/rma/stout.zip", codename: "stout" },
-      {
-        url: "https://dl.diffusehyperion.com/rma/strongbad.zip",
-        codename: "strongbad",
+      { url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/orco.zip", codename: "orco" },
+      { url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/pyro.zip", codename: "pyro" },
+      { url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/reks.zip", codename: "reks" },
+      { 
+        url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/sentry.zip", 
+        codename: "sentry" 
       },
-      { url: "https://dl.diffusehyperion.com/rma/tidus.zip", codename: "tidus" },
-      {
-        url: "https://dl.diffusehyperion.com/rma/ultima.zip",
-        codename: "ultima",
+      { url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/stout.zip", codename: "stout" },
+      { 
+        url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/strongbad.zip", 
+        codename: "strongbad" 
       },
-      {
-        url: "https://dl.diffusehyperion.com/rma/volteer.zip",
-        codename: "volteer",
+      { url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/tidus.zip", codename: "tidus" },
+      { url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/ultima.zip", codename: "ultima" },
+      { 
+        url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/volteer.zip", 
+        codename: "volteer" 
       },
-      { url: "https://dl.diffusehyperion.com/rma/zork.zip", codename: "zork" },
+      { url: "https://dl.darkn.bio/api/raw/?path=/SH1mmer/zork.zip", codename: "zork" },
     ],
   },
   {
-    name: "NotDarkn Mirror",
+    name: "DiffuseHyperion Mirror",
     shims: [
-      { url: "https://dl.darkn.bio/SH1mmer/ambassador.zip", codename: "ambassador" },
-      { url: "https://dl.darkn.bio/SH1mmer/brask.zip", codename: "brask" },
-      { url: "https://dl.darkn.bio/SH1mmer/brya.zip", codename: "brya" },
-      { url: "https://dl.darkn.bio/SH1mmer/clapper.zip", codename: "clapper" },
-      { url: "https://dl.darkn.bio/SH1mmer/coral.zip", codename: "coral" },
-      { url: "https://dl.darkn.bio/SH1mmer/corsola.zip", codename: "corsola" },
-      { url: "https://dl.darkn.bio/SH1mmer/dedede.zip", codename: "dedede" },
-      { url: "https://dl.darkn.bio/SH1mmer/enguarde.zip", codename: "enguarde" },
-      { url: "https://dl.darkn.bio/SH1mmer/glimmer.zip", codename: "glimmer" },
-      { url: "https://dl.darkn.bio/SH1mmer/grunt.zip", codename: "grunt" },
-      { url: "https://dl.darkn.bio/SH1mmer/hana.zip", codename: "hana" },
-      { url: "https://dl.darkn.bio/SH1mmer/hatch.zip", codename: "hatch" },
-      { url: "https://dl.darkn.bio/SH1mmer/jacuzzi.zip", codename: "jacuzzi" },
-      { url: "https://dl.darkn.bio/SH1mmer/kefka.zip", codename: "kefka" },
-      { url: "https://dl.darkn.bio/SH1mmer/kukui.zip", codename: "kukui" },
-      { url: "https://dl.darkn.bio/SH1mmer/lulu.zip", codename: "lulu" },
-      { url: "https://dl.darkn.bio/SH1mmer/nami.zip", codename: "nami" },
-      { url: "https://dl.darkn.bio/SH1mmer/octopus.zip", codename: "octopus" },
-      { url: "https://dl.darkn.bio/SH1mmer/orco.zip", codename: "orco" },
-      { url: "https://dl.darkn.bio/SH1mmer/pyro.zip", codename: "pyro" },
-      { url: "https://dl.darkn.bio/SH1mmer/reks.zip", codename: "reks" },
-      { url: "https://dl.darkn.bio/SH1mmer/sentry.zip", codename: "sentry" },
-      { url: "https://dl.darkn.bio/SH1mmer/stout.zip", codename: "stout" },
-      { url: "https://dl.darkn.bio/SH1mmer/strongbad.zip", codename: "strongbad" },
-      { url: "https://dl.darkn.bio/SH1mmer/tidus.zip", codename: "tidus" },
-      { url: "https://dl.darkn.bio/SH1mmer/ultima.zip", codename: "ultima" },
-      { url: "https://dl.darkn.bio/SH1mmer/volteer.zip", codename: "volteer" },
-      { url: "https://dl.darkn.bio/SH1mmer/zork.zip", codename: "zork" },
+      { url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/brask.zip", codename: "brask" },
+      { url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/brya.zip", codename: "brya" },
+      {
+        url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/clapper.zip",
+        codename: "clapper",
+      },
+      { url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/coral.zip", codename: "coral" },
+      {
+        url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/corsola.zip",
+        codename: "corsola",
+      },
+      {
+        url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/dedede.zip",
+        codename: "dedede",
+      },
+      {
+        url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/enguarde.zip",
+        codename: "enguarde",
+      },
+      {
+        url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/glimmer.zip",
+        codename: "glimmer",
+      },
+      { url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/grunt.zip", codename: "grunt" },
+      { url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/hana.zip", codename: "hana" },
+      { url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/hatch.zip", codename: "hatch" },
+      {
+        url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/jacuzzi.zip",
+        codename: "jacuzzi",
+      },
+      { url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/kefka.zip", codename: "kefka" },
+      { url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/kukui.zip", codename: "kukui" },
+      { url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/nami.zip", codename: "nami" },
+      { url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/nissa.zip", codename: "nissa" },
+      {
+        url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/octopus.zip",
+        codename: "octopus",
+      },
+      { url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/orco.zip", codename: "orco" },
+      { url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/pyro.zip", codename: "pyro" },
+      { url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/reks.zip", codename: "reks" },
+      {
+        url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/sentry.zip",
+        codename: "sentry",
+      },
+      { url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/stout.zip", codename: "stout" },
+      {
+        url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/strongbad.zip",
+        codename: "strongbad",
+      },
+      { url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/tidus.zip", codename: "tidus" },
+      {
+        url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/ultima.zip",
+        codename: "ultima",
+      },
+      {
+        url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/volteer.zip",
+        codename: "volteer",
+      },
+      { url: "https://dl.diffusehyperion.com/api/raw/?path=/rma/zork.zip", codename: "zork" },
     ],
   },
   {


### PR DESCRIPTION
## list of changes
- added `nissa` shims to both NotDarkn's Mirror and DiffuseHyperion's Mirror
- added `kefka` shims to DiffuseHyperion's Mirror
  - will ask DiffuseHyperion to add `ambassador` and `lulu` shims to his mirror
  - if he does so in time before this pr is merged (or closed), it'll be added
- move NotDarkn's mirror above DiffuseHyperion's mirror
  - due to DiffuseHyperion's inactivity, it's unknown when his mirror could go down or whatnot
  - also due to his lack of updates, it'd be better to prioritize NotDarkn's mirror instead
- change both download URLs for NotDarkn's Mirror and DiffuseHyperion's Mirror to raw/direct links
  - this allows the user to click on the URL and download it instantly, kxtzownsu Mirror's is like this already
- kind of/slightly organize NotDarkn's Mirror code due to the added length by the raw/direct URLs

## proof of functionality
https://github.com/e9x/chrome100/assets/73033672/a2d2676d-708f-422d-a92b-d2930fb06765